### PR TITLE
Use which to find firefox binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - npm install mozilla-download -g
   - pwd
   - cd ..
-  - mozilla-download --branch nightly -c prerelease --host ftp.mozilla.org firefox
+  - mozilla-download --branch nightly firefox
   - cd $TRAVIS_BUILD_DIR
   - pwd
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,7 +23,13 @@ function normalizeBinary (binaryPath, platform, arch) {
   return when.promise(function(resolve, reject) {
     platform = platform || os.platform();
     arch = arch || os.arch();
-    binaryPath = binaryPath || process.env.JPM_FIREFOX_BINARY || "firefox";
+    var systemFirefox;
+    if (platform !== "windows") {
+      // Only use which on non-windows for now, windows PATH is usually dodgy
+      systemFirefox = which.sync("firefox");
+    }
+    binaryPath = binaryPath || process.env.JPM_FIREFOX_BINARY ||
+                 systemFirefox || "firefox";
 
     arch = /64/.test(arch) ? "(64)" : "";
     platform = /darwin/i.test(platform) ? "osx" :
@@ -108,12 +114,12 @@ normalizeBinary.paths = {
   "aurora on osx": "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin",
   "nightly on osx": "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin",
 
-  "firefox on linux": which.sync("firefox"),
+  "firefox on linux": "/usr/lib/firefox",
   "beta on linux": "/usr/lib/firefox-beta",
   "aurora on linux": "/usr/lib/firefox-aurora",
   "nightly on linux": "/usr/lib/firefox-nightly",
 
-  "firefox on linux(64)": which.sync("firefox"),
+  "firefox on linux(64)": "/usr/lib64/firefox",
   "beta on linux(64)": "/usr/lib64/firefox-beta",
   "aurora on linux(64)": "/usr/lib64/firefox-aurora",
   "nightly on linux(64)" : "/usr/lib64/firefox-nightly"

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,7 @@ var path = require("path");
 var os = require("os");
 var Winreg = require('winreg');
 var when = require("when");
+var which = require("which");
 
 /**
  * Takes a path to a binary file (like `/Applications/FirefoxNightly.app`)
@@ -107,12 +108,12 @@ normalizeBinary.paths = {
   "aurora on osx": "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin",
   "nightly on osx": "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin",
 
-  "firefox on linux": "/usr/lib/firefox",
+  "firefox on linux": which.sync("firefox"),
   "beta on linux": "/usr/lib/firefox-beta",
   "aurora on linux": "/usr/lib/firefox-aurora",
   "nightly on linux": "/usr/lib/firefox-nightly",
 
-  "firefox on linux(64)": "/usr/lib64/firefox",
+  "firefox on linux(64)": which.sync("firefox"),
   "beta on linux(64)": "/usr/lib64/firefox-beta",
   "aurora on linux(64)": "/usr/lib64/firefox-aurora",
   "nightly on linux(64)" : "/usr/lib64/firefox-nightly"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chai": "1.10.0",
     "dive": "0.3.1",
     "mocha": "2.1.0",
-    "sandboxed-module": "2.0.0"
+    "sandboxed-module": "2.0.0",
+    "which": "^1.1.1"
   }
 }

--- a/test/run/test.utils.js
+++ b/test/run/test.utils.js
@@ -6,6 +6,7 @@
 var os = require("os");
 var fs = require("fs");
 var path = require("path");
+var which = require("which");
 var chai = require("chai");
 var expect = chai.expect;
 var utils = require("../../lib/utils");
@@ -75,6 +76,7 @@ describe("lib/utils", function () {
 
   it("normalizeBinary() default sets (non-windows)", function (done) {
     delete process.env.JPM_FIREFOX_BINARY;
+    var systemFirefox = which.sync("firefox");
     var args = 0;
     var expected = 1;
 
@@ -86,7 +88,7 @@ describe("lib/utils", function () {
     ].map(function(fixture) {
       var promise = binary.apply(binary, fixture[args]);
       return promise.then(function(actual) {
-        expect(actual).to.be.equal(fixture[expected]);
+        expect([systemFirefox, fixture[expected]]).to.contain(actual);
       });
     });
     all(promises).then(done.bind(null, null), done);


### PR DESCRIPTION
So I'm not sure if this is now the official repo or not, it was under @erikvold but that seems deleted. In any case, re-creating this pull request for consideration - the issue was filed there, but the summary is that some Linux versions (notably Ubuntu+derivatives) do not have Firefox located at the path expected by this module. This means that things like `jpm run` require a command line flag `-b=/usr/bin/firefox` to work. These changes fix that, at least for non-Windows and vanilla (non-nightly/etc.) Firefox.

Thanks for your consideration, let me know if there's somewhere else this should go.